### PR TITLE
fix: typo in attribute for Sprind-Funke test

### DIFF
--- a/lib/circuits/mdoc/mdoc_zk_test.cc
+++ b/lib/circuits/mdoc/mdoc_zk_test.cc
@@ -141,7 +141,7 @@ static const RequestedAttribute birthdate_1998_09_04 = {
     .value_len = 10};
 
 static const RequestedAttribute height_175 = {
-    {'h', 'e', 'i', 'g', 'h', 't', 'h'}, {0x18, 0xaf}, 6, 2};
+    {'h', 'e', 'i', 'g', 'h', 't'}, {0x18, 0xaf}, 6, 2};
 
 TEST_F(MdocZKTest, one_claim) {
   const Claims tests[] = {{


### PR DESCRIPTION
not sure why this wasn't popping up as an error in the test suite, there was a typo in how id 'height' is spelled in the height_175 attribute. It was breaking my own tests, now fixed.