### PR TITLE
Add missing Debian/Ubuntu build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ googlebenchmark.
 ### Ubuntu, debian
 
 ```
-$ sudo apt install libssl-dev libzstd-dev libgtest-dev libbenchmark-dev zlib1g-dev
+$ sudo apt install clang cmake libssl-dev libzstd-dev libgtest-dev libbenchmark-dev zlib1g-dev
 ```
 
 ### Fedora, redhat


### PR DESCRIPTION
Found these to be necessary on a fresh Ubuntu 24.04.2 server install.