### PR TITLE
Revert "Fix link to report"

### DIFF
--- a/docs/content/en/docs/reviews.md
+++ b/docs/content/en/docs/reviews.md
@@ -9,7 +9,7 @@ This page documents the security reviews of Longfellow that have been completed 
 
 ## Trail of Bits
 Trail of Bits has reviewed our system and produced a 
-[report](../../../static/reviews/Longfellow_report_2025_08_18.pdf). All of the issues have been addressed in the latest release.  To briefly comment on the issues marked "High" severity:
+[report](../../reviews/Longfellow_report_2025_08_18.pdf). All of the issues have been addressed in the latest release.  To briefly comment on the issues marked "High" severity:
 
 1. Issue #1: The report noted that our library does not read each circuit to verify its hash.  Because our library is intended to be used in a high-performance server, our library provides these methods, but does not perform the check in *each* call to the verifier method. Instead, we expect a proper verifier implementation to perform this costly check once upon start and then cache the circuits in memory.  Our reference verifier implementation illustrates how this can be done.
 


### PR DESCRIPTION
Reverts google/longfellow-zk#76

This breaks the generated docs