### PR TITLE
Correct name of curve in FieldID table

### DIFF
--- a/docs/specs/libzk.md
+++ b/docs/specs/libzk.md
@@ -376,7 +376,7 @@ GF(2^16^)                     |   0x05
 2^64 - 59                     |   0x07
 2^64 - 2^32 + 1               |   0x08
 F_{2^64 - 59}^2^              |   0x09
-secp256                       |   0x0a
+secp256k1                     |   0x0a
 F_{2^{0--15}^-byte prime}^2^  |   0xe{0--f}
 F_{2^{0--15}^-byte prime}     |   0xf{0--f}
 Table: Finite field identifiers.


### PR DESCRIPTION
The FieldID table lists "secp256", which is incomplete. This must be referring to "secp256k1", a.k.a. "the Bitcoin curve". There is also "secp256r1", which is also known as "NIST P-256", which appears earlier in the table.

I didn't regenerate the xml/txt/html files, as there appears to be some drift already, and I don't have the same version of `xml2rfc` installed locally.