### PR TITLE
docs(spec): fix Ligero parameters, constraints, and quadratic layout

### DIFF
--- a/lib/ligero/ligero_param.h
+++ b/lib/ligero/ligero_param.h
@@ -133,7 +133,7 @@ struct LigeroParam {
   size_t w;           // number of witnesses in a witness block
   size_t nwrow;       // number of witness rows
   size_t nqtriples;   // number of triples of quadratic-check rows
-  size_t nwqrow;      // nwqrow + nqtriples
+  size_t nwqrow;      // nwrow + 3 * nqtriples;
   size_t nrow;        // total number of rows (nwqrow + three blinding rows)
   size_t mc_pathlen;  // length of a Merkle-tree proof
                       // with BLOCK_ENC-BLOCK leaves


### PR DESCRIPTION
**This PR is documentation-only plus comment fixes; no functional behavior is changed.**

This PR corrects several inconsistencies in `docs/specs/ligero.md` relative to the implementation and the Ligero construction, primarily around row/column accounting, parameter definitions, and quadratic-row layout.

### Changes:
#### A) In `docs/specs/ligero.md`
1. **Define missing parameter:**
Define `NW` (total number of witnesses), which is used later in `inner_product_vector`.
3. **Fix row-count formulas:**
- Correct the number of rows used to encode witnesses and quadratic constraints:
    * `NQW = NWROW + 3 * NQT`,
- Correct the total number of rows in the witness matrix `T`:
    * `NROW = NQW + 3` (three blinding rows are added to the witness matrix `T`).
3. **Fix inconsistent constraints on parameters**
- Remove redundant constraints:
    * `BLOCK > NREQ` (redundant given `BLOCK = NREQ + WR`).
- Remove mutually inconsistent inequalities involving `BLOCK`:`BLOCK = NREQ + WR`, `BLOCK >= 2 * (NREQ + QR) + (NREQ + WR) - 2`, `BLOCK >= 2 * (NREQ + WR) - 1`, and Replace them with the correct quadratic-row length constraint
    * `DBLOCK = 2 * (NREQ + WR) - 1`
- Explicitly state the number of tableau columns (denoted `BLOCK_ENC` in code):
    * `NCOL = DBLOCK + ceil(BLOCK / rate)`

4. **Fix undefined identifier**
- Replace the undefined identifier `Q` with `QR` in the `layout_quadratic_rows` pseudocode.

5. **Fix quadratic row layout**
- Correct the row indexing in `layout_quadratic_rows` to match the intended layout:
     * all `x` rows first, followed by all `y` rows, then all `z` rows.
   * This matches both `ligero_param.h` and the triple-row structure described in the Ligero paper.

6. **Fix inner-product vector layout**
- Correct the coefficient-vector sizing text in `inner_product_vector`.
- Update the offsets (`a_x`, `a_y`, `a_z`) to reflect the corrected row layout and dimensions.


#### B) In `lib/ligero/ligero_param.h`
7. **Fix misleading comment**
- Correct the comment describing `nwqrow`:
     * `nwqrow = nwrow + 3 * nqtriples;`